### PR TITLE
Added compatibility for Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enum_filter"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Filter by enum variant in Bevy queries"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enum_filter"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Filter by enum variant in Bevy queries"
@@ -14,12 +14,12 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.11", default_features = false }
-bevy_ecs = { version = "0.11", default_features = false }
+bevy_app = { version = "0.12", default_features = false }
+bevy_ecs = { version = "0.12", default_features = false }
 bevy_enum_filter_derive = { path = "./bevy_enum_filter_derive", version = "0.1.0" }
 
 [dev-dependencies]
-bevy = "0.11"
+bevy = "0.12"
 
 [[example]]
 name = "filtering"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn main() {
 Add the following to the `[dependencies]` section of your `Cargo.toml`.
 
 ```text
-bevy_enum_filter = "0.1"
+bevy_enum_filter = "0.2.1"
 ```
 
 ## 🤨 How it works
@@ -80,4 +80,4 @@ If you need it to run after a certain system or within a certain stage, you coul
 | :----- | ---------------- |
 | 0.8.1  | 0.1.0            |
 | 0.11.x | 0.2.0            |
-
+| 0.12.x | 0.2.1            |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn main() {
 Add the following to the `[dependencies]` section of your `Cargo.toml`.
 
 ```text
-bevy_enum_filter = "0.2.1"
+bevy_enum_filter = "0.3.0"
 ```
 
 ## 🤨 How it works
@@ -80,4 +80,4 @@ If you need it to run after a certain system or within a certain stage, you coul
 | :----- | ---------------- |
 | 0.8.1  | 0.1.0            |
 | 0.11.x | 0.2.0            |
-| 0.12.x | 0.2.1            |
+| 0.12.x | 0.3.0            |


### PR DESCRIPTION
This is just a simple thing to update the Cargo.toml to add support for the latest version of Bevy.