### PR TITLE
Fixed that query.iter().len() is 0 on the first frame.

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,6 +1,7 @@
 use crate::filter_trait::EnumFilter;
+use crate::systems::create_marker_for_enum;
 use crate::systems::watch_for_enum;
-use bevy_app::{App, Update};
+use bevy_app::{App, PostStartup, Update};
 
 /// Extension trait for [`App`] that enables adding an [enum filter].
 ///
@@ -17,6 +18,8 @@ pub trait AddEnumFilter {
 
 impl AddEnumFilter for App {
     fn add_enum_filter<T: EnumFilter>(&mut self) -> &mut Self {
-        self.add_systems(Update, watch_for_enum::<T>)
+        self
+        .add_systems(PostStartup, create_marker_for_enum::<T>)
+        .add_systems(Update, watch_for_enum::<T>)
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -15,3 +15,16 @@ pub fn watch_for_enum<T: EnumFilter>(
         T::set_marker(&mut commands.entity(entity), value);
     }
 }
+
+/// A system that queries all Entities with a given enum component.
+///
+/// This system will be applied `PostStartup`, so that from the first `Update` you can access whatever items are returned from the query.
+/// Useful when you need to call `query.single()` or `query.single_mut()` since `watch_for_enum` will return 0 Entities for the first frame.
+pub fn create_marker_for_enum<T: EnumFilter>(
+    mut commands: Commands,
+    query: Query<(Entity, &T)>,
+) {
+    for (entity, value) in &query {
+        T::set_marker(&mut commands.entity(entity), value);
+    }
+}


### PR DESCRIPTION
With the changes in this PR, the marker structs will be registered in the `PostStartup` schedule (in addition to the original `Update`) allowing for [any schedule](https://github.com/bevyengine/bevy/blob/main/crates/bevy_app/src/main_schedule.rs#L12) that follows this to access the query.

One of the things I've noticed is when using this within a query, the query isn't populated immediately.  
I think this is due to the `Changed` filter.

Consider the following example, that now works:
```rust
fn player_movement(mut query: Query<(&mut Transform), With<Enum!(app::Tag::Player)>>) {
    let mut transform = query.single_mut();
    // Do some mutations here...
}
```

This is not possible in the original code, and in fact, if we were to just change the body to `println!("{}", query.iter_mut().len())` then we'd see the console print the value `0`, before printing a sea of `1`.

Currently we have to implement the code in the following way:
```rust
fn player_movement(mut query: Query<(&mut Transform), With<Enum!(app::Tag::Player)>>) {
    if query.is_empty() {
        return;
    }

    let mut transform = query.single_mut();
    // Do some mutations here...
}
```