### PR TITLE
Updated to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enum_filter"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Filter by enum variant in Bevy queries"
@@ -14,12 +14,12 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.12", default_features = false }
-bevy_ecs = { version = "0.12", default_features = false }
+bevy_app = { version = "0.13", default_features = false }
+bevy_ecs = { version = "0.13", default_features = false }
 bevy_enum_filter_derive = { path = "./bevy_enum_filter_derive", version = "0.1.0" }
 
 [dev-dependencies]
-bevy = "0.12"
+bevy = "0.13"
 
 [[example]]
 name = "filtering"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enum_filter"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Filter by enum variant in Bevy queries"
@@ -14,12 +14,12 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.13", default_features = false }
-bevy_ecs = { version = "0.13", default_features = false }
+bevy_app = { version = "0.14", default_features = false }
+bevy_ecs = { version = "0.14", default_features = false }
 bevy_enum_filter_derive = { path = "./bevy_enum_filter_derive", version = "0.1.0" }
 
 [dev-dependencies]
-bevy = "0.13"
+bevy = "0.14"
 
 [[example]]
 name = "filtering"

--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ If you need it to run after a certain system or within a certain stage, you coul
 | 0.8.1  | 0.1.0            |
 | 0.11.x | 0.2.0            |
 | 0.12.x | 0.3.0            |
+| 0.13.x | 0.4.0            |

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ If you need it to run after a certain system or within a certain stage, you coul
 | 0.11.x | 0.2.0            |
 | 0.12.x | 0.3.0            |
 | 0.13.x | 0.4.0            |
+| 0.14.x | 0.5.0            |
+

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ fn main() {
 
 Add the following to the `[dependencies]` section of your `Cargo.toml`.
 
-```text
-bevy_enum_filter = "0.3.0"
+```toml
+bevy_enum_filter = "0.5.0"
 ```
 
 ## 🤨 How it works

--- a/examples/filtering.rs
+++ b/examples/filtering.rs
@@ -26,14 +26,14 @@ enum Choice {
     C,
 }
 
-fn spawn(mut commands: Commands, input: Res<Input<KeyCode>>) {
-    if input.just_pressed(KeyCode::A) {
+fn spawn(mut commands: Commands, input: Res<ButtonInput<KeyCode>>) {
+    if input.just_pressed(KeyCode::KeyA) {
         commands.spawn((Choice::A,));
     }
-    if input.just_pressed(KeyCode::B) {
+    if input.just_pressed(KeyCode::KeyB) {
         commands.spawn((Choice::B,));
     }
-    if input.just_pressed(KeyCode::C) {
+    if input.just_pressed(KeyCode::KeyC) {
         commands.spawn((Choice::C,));
     }
 }

--- a/examples/importing.rs
+++ b/examples/importing.rs
@@ -47,14 +47,14 @@ mod systems {
     use super::components::{choice_filters, Choice};
     // ! === Import Enum AND Filter Module === ! //
 
-    pub fn spawn(mut commands: Commands, input: Res<Input<KeyCode>>) {
-        if input.just_pressed(KeyCode::A) {
+    pub fn spawn(mut commands: Commands, input: Res<ButtonInput<KeyCode>>) {
+        if input.just_pressed(KeyCode::KeyA) {
             commands.spawn((Choice::A,));
         }
-        if input.just_pressed(KeyCode::B) {
+        if input.just_pressed(KeyCode::KeyB) {
             commands.spawn((Choice::B,));
         }
-        if input.just_pressed(KeyCode::C) {
+        if input.just_pressed(KeyCode::KeyC) {
             commands.spawn((Choice::C,));
         }
     }

--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -25,7 +25,7 @@ enum Toggle {
     Off,
 }
 
-fn toggle(mut query: Query<&mut Toggle>, input: Res<Input<KeyCode>>) {
+fn toggle(mut query: Query<&mut Toggle>, input: Res<ButtonInput<KeyCode>>) {
     if input.just_pressed(KeyCode::Space) {
         for mut state in &mut query {
             match *state {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,6 +1,7 @@
 use crate::filter_trait::EnumFilter;
+use crate::systems::create_marker_for_enum;
 use crate::systems::watch_for_enum;
-use bevy_app::{App, Update};
+use bevy_app::{App, PostStartup, Update};
 
 /// Extension trait for [`App`] that enables adding an [enum filter].
 ///
@@ -17,6 +18,8 @@ pub trait AddEnumFilter {
 
 impl AddEnumFilter for App {
     fn add_enum_filter<T: EnumFilter>(&mut self) -> &mut Self {
-        self.add_systems(Update, watch_for_enum::<T>)
+        self
+        .add_systems(PostStartup, create_marker_for_enum::<T>)
+        .add_systems(Update, watch_for_enum::<T>)
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -15,3 +15,16 @@ pub fn watch_for_enum<T: EnumFilter>(
         T::set_marker(&mut commands.entity(entity), value);
     }
 }
+
+/// A system that queries all Entities with a given enum component.
+///
+/// This system will be applied `PostStartup`, so that from the first `Update` you can access whatever items are returned from the query.
+/// Useful when you need to call `query.single()` or `query.single_mut()` since `watch_for_enum` will return 0 Entities for the first frame.
+pub fn create_marker_for_enum<T: EnumFilter>(
+    mut commands: Commands,
+    query: Query<(Entity, &T)>,
+) {
+    for (entity, value) in &query {
+        T::set_marker(&mut commands.entity(entity), value);
+    }
+}


### PR DESCRIPTION
Extends/also applies #5 (0.13 patch).

This utility still seems useful to me, though I wish this was a part of the engine to make it work more like `With` and `Without` (which bevy knows as correctly disjoint queries). Still thought I would share the patch for anyone else to use.
~~I will also merge #4 into [my fork's main branch](https://github.com/mikkelens/bevy_enum_filter/tree/main), for convenience of other non-maintainers.~~